### PR TITLE
Add PointerAwarePageView and update dependencies

### DIFF
--- a/.github/workflows/ci_end_to_end_ios.yml
+++ b/.github/workflows/ci_end_to_end_ios.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         device:
-          - iPhone 8 (13.6)
+          - iPhone 8 (13.7)
       fail-fast: false
     runs-on: macOS-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ lib/generated_plugin_registrant.dart
 # Symbolication related
 app.*.symbols
 
+# Generated code related
+**/test/**/*.g.dart
+**/test/**/*.freezed.dart
+
+# Coverage related
+/coverage/
+
 # Obfuscation related
 app.*.map.json
 

--- a/lib/feature/game/presentation/page/game.dart
+++ b/lib/feature/game/presentation/page/game.dart
@@ -2,6 +2,7 @@ import 'package:Timba/feature/game/domain/card_params.dart';
 import 'package:Timba/feature/game/domain/card_type.dart';
 import 'package:Timba/feature/game/domain/get_card_use_case.dart';
 import 'package:Timba/feature/game/presentation/widget/hand.dart';
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view.dart';
 import 'package:Timba/injection.dart';
 import 'package:flutter/material.dart';
 
@@ -10,15 +11,12 @@ class Game extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    PageController controller = PageController();
     return Scaffold(
       body: MediaQuery.removePadding(
         context: context,
         removeTop: true,
-        child: PageView(
+        child: PointerAwarePageView(
           key: Key("pageview"),
-          controller: controller,
-          scrollDirection: Axis.vertical,
           children: [
             Hand(provideCard: getStoryPoint),
             Hand(provideCard: getShirtSize),

--- a/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view.dart
+++ b/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc.dart';
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_event.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class PointerAwarePageView extends StatelessWidget {
+  final List<Widget> children;
+
+  const PointerAwarePageView({Key key, this.children}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    PageController controller = PageController(viewportFraction: 1);
+    return BlocProvider<PointerAwarePageViewInteractionBloc>(
+      create: (context) => PointerAwarePageViewInteractionBloc(true),
+      child: BlocBuilder<PointerAwarePageViewInteractionBloc, bool>(
+        builder: (context, physicsEnabled) {
+          // ignore: close_sinks
+          final PointerAwarePageViewInteractionBloc bloc =
+              BlocProvider.of<PointerAwarePageViewInteractionBloc>(context);
+
+          return Listener(
+            onPointerSignal: (pointerSignal) {
+              if (pointerSignal is PointerScrollEvent) {
+                bloc.add(
+                    PointerAwarePageViewInteractionEvent.startPointerScroll);
+                Future(() {
+                  Future.delayed(Duration(milliseconds: 400), () {
+                    bloc.add(
+                        PointerAwarePageViewInteractionEvent.endPointerScroll);
+                  });
+                  final currentPage = controller.page.round();
+                  final nextPage = pointerSignal.scrollDelta.dy >= 0.0
+                      ? min(currentPage + 1, children.length - 1)
+                      : max(0, currentPage - 1);
+                  controller.animateToPage(
+                    nextPage,
+                    duration: Duration(milliseconds: 400),
+                    curve: Curves.decelerate,
+                  );
+                });
+              }
+            },
+            child: PageView(
+              physics: physicsEnabled
+                  ? ScrollPhysics()
+                  : NeverScrollableScrollPhysics(),
+              controller: controller,
+              scrollDirection: Axis.vertical,
+              children: children,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc.dart
+++ b/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc.dart
@@ -1,0 +1,20 @@
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_event.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class PointerAwarePageViewInteractionBloc
+    extends Bloc<PointerAwarePageViewInteractionEvent, bool> {
+  PointerAwarePageViewInteractionBloc(bool initialState) : super(initialState);
+
+  @override
+  Stream<bool> mapEventToState(
+      PointerAwarePageViewInteractionEvent event) async* {
+    switch (event) {
+      case PointerAwarePageViewInteractionEvent.startPointerScroll:
+        yield false;
+        break;
+      case PointerAwarePageViewInteractionEvent.endPointerScroll:
+        yield true;
+        break;
+    }
+  }
+}

--- a/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_event.dart
+++ b/lib/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_event.dart
@@ -1,0 +1,1 @@
+enum PointerAwarePageViewInteractionEvent { startPointerScroll, endPointerScroll }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   bazel_worker:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.1.0"
   bloc_test:
     dependency: "direct dev"
     description:
@@ -63,7 +63,7 @@ packages:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   build:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.1"
+    version: "2.11.3"
   build_resolvers:
     dependency: transitive
     description:
@@ -105,14 +105,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.2"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "6.0.1"
   build_web_compilers:
     dependency: "direct dev"
     description:
@@ -140,14 +140,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -168,21 +168,21 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "3.5.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -196,7 +196,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.11"
+    version: "0.14.1"
   crypto:
     dependency: transitive
     description:
@@ -238,14 +238,21 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.0.0-nullsafety.2"
   fixnum:
     dependency: transitive
     description:
@@ -288,14 +295,14 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.6"
+    version: "0.12.2"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0+1"
+    version: "0.12.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -307,7 +314,7 @@ packages:
       name: get_it
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.4"
+    version: "5.0.1"
   glob:
     dependency: transitive
     description:
@@ -335,7 +342,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+3"
+    version: "0.14.0+4"
   http:
     dependency: transitive
     description:
@@ -363,28 +370,21 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.14"
+    version: "2.1.18"
   injectable:
     dependency: "direct main"
     description:
       name: injectable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   injectable_generator:
     dependency: "direct dev"
     description:
       name: injectable_generator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "1.0.5"
   io:
     dependency: transitive
     description:
@@ -398,21 +398,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety"
+    version: "0.6.3-nullsafety.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   json_rpc_2:
     dependency: transitive
     description:
       name: json_rpc_2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   logging:
     dependency: transitive
     description:
@@ -426,14 +426,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.4"
   mime:
     dependency: transitive
     description:
@@ -489,14 +489,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.14"
+    version: "1.6.21"
   path_provider_linux:
     dependency: transitive
     description:
@@ -510,7 +510,7 @@ packages:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "0.0.4+4"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -518,48 +518,55 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4+1"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.4"
+    version: "3.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0-nullsafety.2"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety"
+    version: "1.5.0-nullsafety.1"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.0.0-nullsafety.2"
   protobuf:
     dependency: transitive
     description:
@@ -641,42 +648,42 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6"
+    version: "0.9.7+1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety"
+    version: "0.10.10-nullsafety.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   stream_transform:
     dependency: transitive
     description:
@@ -690,7 +697,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   sync_http:
     dependency: transitive
     description:
@@ -704,28 +711,28 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.2"
+    version: "1.16.0-nullsafety.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.2"
+    version: "0.3.12-nullsafety.5"
   timing:
     dependency: transitive
     description:
@@ -739,21 +746,21 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "5.2.0"
   vm_service_client:
     dependency: transitive
     description:
@@ -789,20 +796,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.7.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.2"
   xml:
     dependency: transitive
     description:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.0"
+    version: "4.5.1"
   yaml:
     dependency: transitive
     description:
@@ -811,5 +825,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
   flutter: ">=1.17.0 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.25"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.3"
+  bloc_test:
+    dependency: "direct dev"
+    description:
+      name: bloc_test
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.0.6"
   boolean_selector:
     dependency: transitive
     description:
@@ -203,7 +217,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -217,7 +231,7 @@ packages:
       name: dartz
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   fake_async:
     dependency: transitive
     description:
@@ -244,6 +258,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.6"
   flutter_driver:
     dependency: "direct dev"
     description: flutter
@@ -255,7 +276,7 @@ packages:
       name: flutter_launcher_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "0.8.1"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -300,7 +321,7 @@ packages:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   graphs:
     dependency: transitive
     description:
@@ -426,7 +447,14 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   node_interop:
     dependency: transitive
     description:
@@ -539,6 +567,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.2+2"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,18 +23,20 @@ dependencies:
     sdk: flutter
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0
   # Google fonts
-  google_fonts: ^1.1.0
+  google_fonts: ^1.1.1
   # Dartz - Functional programming
-  dartz: ^0.9.1
+  dartz: ^0.9.2
   # Freezed - Data classes, sealed classes
   freezed_annotation:
   # Mockito - Mocking
-  mockito: ^4.1.1
+  mockito: ^4.1.2
   # Injectable & Get it - Dependency injection
   injectable:
   get_it:
+  # BLoC - Architecture
+  flutter_bloc: ^6.0.6
 
 dev_dependencies:
   flutter_driver:
@@ -44,7 +46,8 @@ dev_dependencies:
   injectable_generator:
   build_runner:
   build_web_compilers:
-  flutter_launcher_icons: ^0.7.5
+  flutter_launcher_icons: ^0.8.1
+  bloc_test: ^7.0.6
 
 flutter_icons:
   android: true

--- a/test/feature/game/presentation/widget/card_test.dart
+++ b/test/feature/game/presentation/widget/card_test.dart
@@ -4,14 +4,16 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../../core/presentation/page/test_widget.dart';
 
 void main() {
-  testWidgets('when card is shown then symbol shown',
-      (WidgetTester tester) async {
-    final symbol = "3";
+  testWidgets(
+    'when card is shown then symbol shown',
+    (WidgetTester tester) async {
+      final symbol = "3";
 
-    await tester.pumpWidget(Test(
-      child: Card(symbol: symbol),
-    ));
+      await tester.pumpWidget(Test(
+        child: Card(symbol: symbol),
+      ));
 
-    expect(find.text(symbol), findsOneWidget);
-  });
+      expect(find.text(symbol), findsOneWidget);
+    },
+  );
 }

--- a/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc_test.dart
+++ b/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc_test.dart
@@ -1,0 +1,28 @@
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_bloc.dart';
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view_interaction_event.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  PointerAwarePageViewInteractionBloc bloc;
+
+  setUp(() {
+    bloc = PointerAwarePageViewInteractionBloc(true);
+  });
+
+  test('when initial state then state is true', () {
+    expect(bloc.state, true);
+  });
+
+  blocTest('when startPointerScroll event emitted then state is false',
+      build: () => bloc,
+      act: (bloc) =>
+          bloc.add(PointerAwarePageViewInteractionEvent.startPointerScroll),
+      expect: [false]);
+
+  blocTest('when endPointerScroll event emitted then state is true',
+      build: () => bloc,
+      act: (bloc) =>
+          bloc.add(PointerAwarePageViewInteractionEvent.endPointerScroll),
+      expect: [true]);
+}

--- a/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_test.dart
+++ b/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_test.dart
@@ -25,8 +25,7 @@ void main() {
       final Offset scrollEventLocation = tester.getCenter(find.byType(PointerAwarePageView));
       final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
       testPointer.hover(scrollEventLocation);
-      final HitTestResult result = tester.hitTestOnBinding(scrollEventLocation);
-      await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 1.0)), result);
+      await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 1.0)));
       await tester.pumpAndSettle();
 
       expect(find.text('2'), findsOneWidget);

--- a/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_test.dart
+++ b/test/feature/game/presentation/widget/pageview/pointer_aware_page_view_test.dart
@@ -1,0 +1,35 @@
+import 'package:Timba/feature/game/presentation/widget/pageview/pointer_aware_page_view.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../core/presentation/page/test_widget.dart';
+
+void main() {
+  testWidgets(
+    'when mouse wheel is scrolled then next page is shown',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Test(
+          child: PointerAwarePageView(
+            children: [
+              Text('1'),
+              Text('2'),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('1'), findsOneWidget);
+
+      final Offset scrollEventLocation = tester.getCenter(find.byType(PointerAwarePageView));
+      final TestPointer testPointer = TestPointer(1, PointerDeviceKind.mouse);
+      testPointer.hover(scrollEventLocation);
+      final HitTestResult result = tester.hitTestOnBinding(scrollEventLocation);
+      await tester.sendEventToBinding(testPointer.scroll(const Offset(0.0, 1.0)), result);
+      await tester.pumpAndSettle();
+
+      expect(find.text('2'), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
# Add PointerAwarePageView and update dependencies

## Description
`PageView` widget works smoothly for touch screens, but it is not responding pretty well to mouse wheel scrolling. So a new widget is created to fullfil this use case. In order to do that `PageView` is wrapped inside a `Listener` widget and if mouse wheel scroll is detected then we disable physics and animate to the next/previous page.